### PR TITLE
fix: work with babel 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,9 @@
   },
   "homepage": "https://github.com/sumul/fractal-react-adapter#readme",
   "dependencies": {
+    "@babel/register": "^7.0.0-beta.44",
     "@frctl/fractal": "^1.1.3",
-    "babel-plugin-module-resolver": "^2.7.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react": "^6.24.1",
-    "babel-register": "^6.24.1",
+    "babel-plugin-module-resolver": "^3.1.1",
     "bluebird": "^3.5.0",
     "html": "^1.0.0",
     "lodash": "^4.17.4",

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -6,7 +6,7 @@ const Adapter     = require('@frctl/fractal').Adapter;
 const React       = require('react');
 const ReactDOM    = require('react-dom/server');
 const prettyPrint = require('html').prettyPrint;
-const babelReg    = require('babel-register');
+const babelReg    = require('@babel/register');
 
 
 /*


### PR DESCRIPTION
fractal-react-adapter doesn't work with Babel 7 (which we are using)

This commit brings in the latest `babel-plugin-module-resolver` and swaps out `babel-register` for `@babel-register`.

WARNING This is a breaking change and would warrant a major version bump. It is breaking because if you are still running Babel 6, then it won't work.